### PR TITLE
[bug] fix query params for pagination on restaurants

### DIFF
--- a/snakebite/controllers/restaurant.py
+++ b/snakebite/controllers/restaurant.py
@@ -31,9 +31,10 @@ class Collection(object):
 
         try:
             # get pagination limits
-            start = int(query_params.get('start', 0))
-            limit = int(query_params.get('limit', 20))
+            start = int(query_params.pop('start', 0))
+            limit = int(query_params.pop('limit', 20))
             end = start + limit
+
         except ValueError as e:
             raise HTTPBadRequest(title='Invalid Value',
                                  description='Invalid arguments in URL query:\n{}'.format(e.message))

--- a/snakebite/tests/controllers/test_restaurant.py
+++ b/snakebite/tests/controllers/test_restaurant.py
@@ -34,6 +34,8 @@ class TestRestaurantCollectionGet(testing.TestBase):
         tests = [
             {'query_string': '', 'expected': {"status": 200, "count": 2}},
             {'query_string': 'description=desc', 'expected': {"status": 200, "count": 2}},
+            {'query_string': 'description=desc&limit=1', 'expected': {"status": 200, "count": 1}},
+            {'query_string': 'description=desc&start=1&limit=2', 'expected': {"status": 200, "count": 1}},
             {'query_string': 'description=description', 'expected': {"status": 200, "count": 1}},
             {'query_string': 'name=c', 'expected': {"status": 200, "count": 0}},
             {'query_string': 'email=b@a.com', 'expected': {"status": 200, "count": 1}},
@@ -43,6 +45,7 @@ class TestRestaurantCollectionGet(testing.TestBase):
             {'query_string': 'tags=x&name=c', 'expected': {"status": 200, "count": 0}},
             {'query_string': 'geolocation=139.731443,35.662836', 'expected': {"status": 200, "count": 1}},
             {'query_string': 'geolocation=ab,cd', 'expected': {"status": 400}},
+            {'query_string': 'limit=1', 'expected': {"status": 200, "count": 1}},
             {'query_string': 'start=2&limit=1', 'expected': {"status": 200, "count": 0}},
             {'query_string': 'start=1limit=1', 'expected': {"status": 400}}
         ]


### PR DESCRIPTION
This PR fixes the limit & offset pagination bug when searching restaurants.

This PR also updates the tests to ensure more robust checking of search parameters.