### PR TITLE
[feature] add /status endpoint to test Snakebite availability

### DIFF
--- a/snakebite/__init__.py
+++ b/snakebite/__init__.py
@@ -7,7 +7,7 @@ import logging
 import os
 from mongoengine import connection
 from logging.handlers import TimedRotatingFileHandler
-from snakebite.controllers import restaurant, tag
+from snakebite.controllers import restaurant, tag, status
 from snakebite.constants import DATETIME_FORMAT
 
 
@@ -32,6 +32,7 @@ class SnakeBite(object):
         self.app.add_route('/restaurants', restaurant.Collection())
         self.app.add_route('/restaurants/{id}', restaurant.Item())
         self.app.add_route('/tags', tag.Collection())
+        self.app.add_route('/status', status.Status())
 
     def cors_middleware(self):
         """

--- a/snakebite/controllers/status.py
+++ b/snakebite/controllers/status.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+import falcon
+import logging
+from snakebite.controllers.hooks import serialize
+from snakebite.models.restaurant import Restaurant
+from snakebite.libs.error import HTTPServiceUnavailable
+
+logger = logging.getLogger(__name__)
+
+
+class Status(object):
+
+    def __init__(self):
+        pass
+
+    @falcon.after(serialize)
+    def on_get(self, req, res):
+        logger.info('status request made')
+        try:
+            Restaurant.objects.limit(1)
+            res.body = {'ok': True}
+            logger.info('database query is successful')
+        except Exception:
+            logger.error('unable to query database successfully.')
+            raise HTTPServiceUnavailable("Snakebite server is currently experiencing issues",
+                                         "Unable to query database successfully")

--- a/snakebite/libs/error.py
+++ b/snakebite/libs/error.py
@@ -26,3 +26,10 @@ class HTTPNotAcceptable(falcon.HTTPNotAcceptable):
     status code: 406
     """
     pass
+
+class HTTPServiceUnavailable(falcon.HTTPServiceUnavailable):
+    """
+    wrapper for HTTP Service Unavailable response
+    status code: 503
+    """
+    pass

--- a/snakebite/tests/controllers/test_status.py
+++ b/snakebite/tests/controllers/test_status.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from falcon import testing
+from snakebite.tests import get_test_snakebite
+from snakebite.controllers import status
+import json
+import mock
+
+
+class TestRestaurantCollectionGet(testing.TestBase):
+
+    def setUp(self):
+        self.resource = status.Status()
+        self.api = get_test_snakebite().app
+
+        self.api.add_route('/status', self.resource)
+        self.srmock = testing.StartResponseMock()
+
+    def tearDown(self):
+        pass
+
+    def test_status_on_get(self):
+
+        res = self.simulate_request('/status', method='GET', headers={'accept': 'application/json'})
+        self.assertTrue(isinstance(res, list))
+        body = json.loads(res[0])
+        self.assertDictEqual(body, {'ok': True})

--- a/snakebite/tests/controllers/test_status.py
+++ b/snakebite/tests/controllers/test_status.py
@@ -5,7 +5,6 @@ from falcon import testing
 from snakebite.tests import get_test_snakebite
 from snakebite.controllers import status
 import json
-import mock
 
 
 class TestRestaurantCollectionGet(testing.TestBase):


### PR DESCRIPTION
This PR adds a `/status` endpoint to test for availability of Snakebite API server as a whole. 

If response's status code is `200`, all is well.