### PR TITLE
[chore] add yums, update menu name to be unique (constraint)

### DIFF
--- a/snakebite/models/restaurant.py
+++ b/snakebite/models/restaurant.py
@@ -23,9 +23,10 @@ class Restaurant(mongo.DynamicDocument):
 
 
 class Menu(mongo.DynamicEmbeddedDocument):
-    name = mongo.StringField()
+    name = mongo.StringField(unique=True)
     price = mongo.DecimalField(min_value=0, required=True)  # defaults to 2 dp, rounded up
     currency = mongo.StringField(required=True, default='JPY')
     rating = mongo.FloatField(min_value=0, max_value=5, default=0)  # current avg rating
     images = mongo.ListField(mongo.URLField())  # list of urls
     tags = mongo.ListField()
+    yums = mongo.IntField(min_value=0, default=0)

--- a/snakebite/tests/controllers/test_restaurant.py
+++ b/snakebite/tests/controllers/test_restaurant.py
@@ -133,7 +133,8 @@ class TestRestaurantCollectionPost(testing.TestBase):
                             "currency": "JPY",
                             "tags": [],
                             "images": ['http://kfc.com/1.jpg'],
-                            "rating": 0.0
+                            "rating": 0.0,
+                            "yums": 0
                         },
                         {
                             "name": "menu B",
@@ -141,7 +142,8 @@ class TestRestaurantCollectionPost(testing.TestBase):
                             "currency": "JPY",
                             "tags": [],
                             "images": ['http://kfc.com/1.jpg'],
-                            "rating": 0.0
+                            "rating": 0.0,
+                            "yums": 0
                         }
                     ]
                 }


### PR DESCRIPTION
This PR updates models in 2 ways:

-  add `yums` field on menus (default to 0, min = 0)
- constrains menu names to be unique within restaurant (possible aiding `restaurant/[id]/menus/[name]` endpoint in future)