### PR TITLE
[feature] add PUT endpoint for restaurants

### DIFF
--- a/snakebite/controllers/restaurant.py
+++ b/snakebite/controllers/restaurant.py
@@ -14,20 +14,12 @@ from mongoengine.errors import DoesNotExist, MultipleObjectsReturned, Validation
 # -------- BEFORE_HOOK functions
 def deserialize_create(req, res, resource):
     deserialize(req, res, resource, schema=RestaurantSchema())
-    print('BEFORE')
-    print(req.params['body'])
-    req.params['body'] = reformat_geolocations_map_to_list(req.params['body'], 'geolocation')
-    print('AFTER')
-    print(req.params['body'])
+    req.params['body'] = reformat_geolocations_map_to_list(req.params['body'], ['geolocation'])
 
 
 def deserialize_update(req, res, id, resource):
     deserialize(req, res, resource, schema=RestaurantSchema())
-    print('BEFORE')
-    print(req.params['body'])
-    req.params['body'] = reformat_geolocations_map_to_list(req.params['body'], 'geolocation')
-    print('AFTER')
-    print(req.params['body'])
+    req.params['body'] = reformat_geolocations_map_to_list(req.params['body'], ['geolocation'])
 
 # -------- END functions
 
@@ -153,5 +145,7 @@ class Item(object):
         restaurant.menus = [Menu(**menu) for menu in menu_data]
 
         restaurant.save()
+
+        restaurant = Restaurant.objects.get(id=id)
         res.body = restaurant
         res.body = reformat_geolocations_point_field_to_map(res.body, 'geolocation')

--- a/snakebite/controllers/schema/common.py
+++ b/snakebite/controllers/schema/common.py
@@ -9,6 +9,10 @@ class Images(colander.SequenceSchema):
     image = colander.SchemaNode(colander.String(), validator=colander.url)
 
 
+class Tags(colander.SequenceSchema):
+    tag = colander.SchemaNode(colander.String())
+
+
 class Geolocation(colander.MappingSchema):
     lon = colander.SchemaNode(colander.Float(), validator=colander.Range(-180, 180), missing=TOKYO_GEOLOCATION['lon'])
     lat = colander.SchemaNode(colander.Float(), validator=colander.Range(-90, 90), missing=TOKYO_GEOLOCATION['lat'])

--- a/snakebite/controllers/schema/restaurant.py
+++ b/snakebite/controllers/schema/restaurant.py
@@ -4,8 +4,8 @@ from __future__ import absolute_import
 import colander
 import decimal
 from snakebite.constants import TWEET_CHAR_LENGTH
-from snakebite.controllers.schema.common import Images, Geolocation
-from snakebite.helpers.schema import CommaList, Currency
+from snakebite.controllers.schema.common import Images, Tags, Geolocation
+from snakebite.helpers.schema import Currency
 
 
 class MenuSchema(colander.MappingSchema):
@@ -13,7 +13,7 @@ class MenuSchema(colander.MappingSchema):
     price = colander.SchemaNode(colander.Decimal(quant='1.00', rounding=decimal.ROUND_UP))  # 2dp, rounded up
     currency = colander.SchemaNode(Currency(), validator=Currency.is_valid, missing='JPY')
     images = Images()
-    tags = colander.SchemaNode(CommaList(), missing='')
+    tags = Tags()
 
 
 class Menus(colander.SequenceSchema):
@@ -26,5 +26,5 @@ class RestaurantSchema(colander.MappingSchema):
     email = colander.SchemaNode(colander.String(), validator=colander.Email(), missing='')
     description = colander.SchemaNode(colander.String(), missing='', validator=colander.Length(max=TWEET_CHAR_LENGTH))
     geolocation = Geolocation()
-    tags = colander.SchemaNode(CommaList(), missing='')
+    tags = Tags()
     menus = Menus()

--- a/snakebite/helpers/geolocation.py
+++ b/snakebite/helpers/geolocation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+from numbers import Number
 
 def reformat_geolocations_map_to_list(dct, geolocation_attr_names):
     """
@@ -29,12 +29,11 @@ def reformat_geolocations_point_field_to_map(obj, geolocation_attr_names):
     takes an object and updates the attributes listed in geolocation_attr_names from a PointField-like map
     and converts these attributes to a simpler {'lon', 'lat'} map instead.
     """
+    if type(geolocation_attr_names) not in [list, str]:
+        raise Exception('either a string of a list of string is required for attribute names')
 
     if type(geolocation_attr_names) is str:
         geolocation_attr_names = [geolocation_attr_names]
-
-    elif type(geolocation_attr_names) is not list:
-        raise Exception('either a string of a list of string is required for attribute names')
 
     for attr_name in geolocation_attr_names:
 
@@ -49,7 +48,9 @@ def reformat_geolocations_point_field_to_map(obj, geolocation_attr_names):
 
 
 def _is_valid_geolocation_map(geolocation):
-    return type(geolocation) is dict and geolocation.get('lon') and geolocation.get('lat')
+    if type(geolocation) is not dict:
+        return False
+    return isinstance(geolocation.get('lon'), Number) and isinstance(geolocation.get('lat'), Number)
 
 
 def _is_valid_geolocation_point_field(geolocation):

--- a/snakebite/tests/controllers/test_restaurant.py
+++ b/snakebite/tests/controllers/test_restaurant.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import
-from copy import deepcopy
 from falcon import testing
 from snakebite.tests import get_test_snakebite
 from snakebite.controllers import restaurant

--- a/snakebite/tests/controllers/test_restaurant.py
+++ b/snakebite/tests/controllers/test_restaurant.py
@@ -83,13 +83,20 @@ class TestRestaurantCollectionPost(testing.TestBase):
             "address": "ueno",
             "email": "kf@c.com",
             "menus": [],
+            "tags": [],
             "geolocation": TOKYO_GEOLOCATION
         }
         base_restaurant.update(kwargs)
         return base_restaurant
 
     def get_mock_menu(self, **kwargs):
-        base_menu = {"name": "some menu", "price": 100.00, "currency": 'JPY', 'images': ['http://kfc.com/1.jpg']}
+        base_menu = {
+            "name": "some menu",
+            "price": 100.00,
+            "currency": 'JPY',
+            "images": ["http://kfc.com/1.jpg"],
+            "tags": []
+        }
         base_menu.update(kwargs)
         return base_menu
 
@@ -374,3 +381,81 @@ class TestRestaurantItemDelete(testing.TestBase):
 
             else:
                 self.assertIsNone(body)
+
+
+class TestRestaurantItemPut(testing.TestBase):
+
+    def setUp(self):
+        self.resource = restaurant.Item()
+        self.api = get_test_snakebite().app
+
+        self.api.add_route('/restaurants/{id}', self.resource)
+        self.srmock = testing.StartResponseMock()
+        self.restaurant = None
+        rst = Restaurant(
+            name='a',
+            description='desc',
+            email='a@b.com',
+            address='Asakusa, Taito-ku, Tokyo',
+            tags=['x', 'y', 'z'],
+            geolocation=[139.79843, 35.712074],
+            menus=[
+                Menu(
+                    name='menu1',
+                    price=100.00,
+                    currency='JPY',
+                    images=[],
+                    tags=['a', 'b']
+                )
+            ]
+        )
+
+        self.restaurant = rst.save()
+
+    def tearDown(self):
+        Restaurant.objects.delete()
+
+    def _get_restaurant_json(self):
+        res = self.simulate_request('/restaurants/{}'.format(self.restaurant.id),
+                                    method="GET",
+                                    headers={'Content-Type': 'application/json'})
+        return res[0]
+
+    def test_item_on_put(self):
+
+        original_restaurant_json = self._get_restaurant_json()
+
+        tests = [
+            {
+                'id': self.restaurant.id,
+                'data': original_restaurant_json,
+                'expected': {
+                    'status': 200,
+                    'body': json.loads(original_restaurant_json)
+                }
+            },
+            {
+                'id': "randomID",
+                'data': original_restaurant_json,
+                'expected': {
+                    'status': 400
+                }
+            }
+        ]
+
+        for t in tests:
+            res = self.simulate_request('/restaurants/{}'.format(t['id']),
+                                        body=t['data'],
+                                        method='PUT',
+                                        headers={'Content-Type': 'application/json'})
+
+            self.assertTrue(isinstance(res, list))
+            body = json.loads(res[0])
+            self.assertTrue(isinstance(body, dict))
+
+            if t['expected']['status'] != 200:
+                self.assertIn('title', body.keys())
+                self.assertIn('description', body.keys())  # error
+
+            else:
+                self.assertDictEqual(t['expected']['body'], body)

--- a/snakebite/tests/controllers/test_restaurant.py
+++ b/snakebite/tests/controllers/test_restaurant.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import
+from copy import deepcopy
 from falcon import testing
 from snakebite.tests import get_test_snakebite
 from snakebite.controllers import restaurant
@@ -424,6 +425,9 @@ class TestRestaurantItemPut(testing.TestBase):
     def test_item_on_put(self):
 
         original_restaurant_json = self._get_restaurant_json()
+        edited_restaurant_json = json.loads(original_restaurant_json)
+        edited_restaurant_json.update({'name': 'Test Name'})
+        edited_restaurant_json = json.dumps(edited_restaurant_json)
 
         tests = [
             {
@@ -432,6 +436,14 @@ class TestRestaurantItemPut(testing.TestBase):
                 'expected': {
                     'status': 200,
                     'body': json.loads(original_restaurant_json)
+                }
+            },
+            {
+                'id': self.restaurant.id,
+                'data': edited_restaurant_json,
+                'expected': {
+                    'status': 200,
+                    'body': json.loads(edited_restaurant_json)
                 }
             },
             {

--- a/snakebite/tests/controllers/test_status.py
+++ b/snakebite/tests/controllers/test_status.py
@@ -4,9 +4,7 @@ from __future__ import absolute_import
 from falcon import testing
 from snakebite.tests import get_test_snakebite
 from snakebite.controllers import status
-from snakebite.libs.error import HTTPServiceUnavailable
 import json
-import mock
 
 
 class TestRestaurantCollectionGet(testing.TestBase):

--- a/snakebite/tests/controllers/test_status.py
+++ b/snakebite/tests/controllers/test_status.py
@@ -4,7 +4,9 @@ from __future__ import absolute_import
 from falcon import testing
 from snakebite.tests import get_test_snakebite
 from snakebite.controllers import status
+from snakebite.libs.error import HTTPServiceUnavailable
 import json
+import mock
 
 
 class TestRestaurantCollectionGet(testing.TestBase):

--- a/snakebite/tests/helpers/test_geolocation.py
+++ b/snakebite/tests/helpers/test_geolocation.py
@@ -48,6 +48,16 @@ class TestGeolocation(testing.TestBase):
                 'attrs': 1234567,
                 'okay': False
             },
+            {
+                'dct': {
+                    'geolocation': {'lon': 12, 'lat': 23},
+                },
+                'attrs': 'locality',  # we did not select right attributes to reformat
+                'okay': True,
+                'expected': {
+                    'geolocation': {'lon': 12, 'lat': 23}
+                }
+            },
         ]
 
         for t in tests:


### PR DESCRIPTION
This PR does the following:
- add PUT endpoint for restaurants (RESTful-style where whole payload is expected)
- fixes validation on geolocation (see below for details)
- changes `tags` schema from commalist to tupleschema for consistency in returned and accepted values


### geolocation validation issues

Previously, by virtue of the validation, a geolocation coordinate of `0.00` would fail the validation since `bool(0) == False`.
Hence, we updated the check to be `isinstance(geolocation.get('lon'), Number)` for stronger and foolproof validation instead