### PR TITLE
[feature] allow search menus by price (min,max)

### DIFF
--- a/snakebite/constants.py
+++ b/snakebite/constants.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import sys
+
 DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S'
 
 TOKYO_GEOLOCATION = {
@@ -8,3 +10,4 @@ TOKYO_GEOLOCATION = {
 }
 
 TWEET_CHAR_LENGTH = 140
+INTEGER_MAX = sys.maxint - 1

--- a/snakebite/controllers/restaurant.py
+++ b/snakebite/controllers/restaurant.py
@@ -8,6 +8,7 @@ from snakebite.controllers.schema.restaurant import RestaurantSchema
 from snakebite.models.restaurant import Restaurant, Menu
 from snakebite.libs.error import HTTPBadRequest
 from snakebite.helpers.geolocation import reformat_geolocations_map_to_list, reformat_geolocations_point_field_to_map
+from snakebite.helpers.range import min_max
 from mongoengine.errors import DoesNotExist, MultipleObjectsReturned, ValidationError
 
 
@@ -45,6 +46,7 @@ class Collection(object):
             raise HTTPBadRequest(title='Invalid Value',
                                  description='Invalid arguments in URL query:\n{}'.format(e.message))
 
+        # custom filters
         # temp dict for updating query filters
         updated_params = {}
 
@@ -81,6 +83,12 @@ class Collection(object):
 
         except Exception:
             raise HTTPBadRequest('Invalid Value', 'geolocation supplied is invalid: {}'.format(geolocation_val))
+
+        if 'price' in query_params:
+            price_range = query_params.pop('price')
+            price_min, price_max = min_max(price_range, type='float')
+            updated_params['menus.price__gte'] = price_min
+            updated_params['menus.price__lte'] = price_max
 
         query_params.update(updated_params)  # update modified params for filtering
 

--- a/snakebite/helpers/geolocation.py
+++ b/snakebite/helpers/geolocation.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from numbers import Number
 
+
 def reformat_geolocations_map_to_list(dct, geolocation_attr_names):
     """
     takes a map object (dct) and updates the attributes listed in geolocation_attr_names from a map of {'lon', 'lat'}

--- a/snakebite/helpers/range.py
+++ b/snakebite/helpers/range.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from snakebite.constants import INTEGER_MAX
+import __builtin__
+
+
+def min_max(range_str, type='int', delimiter=',', min=0, max=INTEGER_MAX):
+    """
+    Parses range_str and returns a tuple of (min, max) value
+    Takes default of min or max if typecasting fails
+    Hence, to get a returned min-max range of (0, 200), you can simply provide ',200'
+    """
+    accepted_types = ['int', 'float']
+    if type not in accepted_types:
+        raise TypeError("Please provide an accepted type: {}".format(accepted_types))
+
+    numberize = getattr(__builtin__, type)
+
+    r = range_str.split(delimiter)[:2]
+    min_val = r[0]
+    max_val = r[1] if len(r) > 1 else ''
+    try:
+        min_val = numberize(min_val)
+    except ValueError:
+        min_val = numberize(min)
+
+    try:
+        max_val = numberize(max_val)
+    except ValueError:
+        max_val = numberize(max)
+
+    if min_val <= max_val:
+        return (min_val, max_val)
+
+    return (max_val, min_val)

--- a/snakebite/tests/controllers/test_restaurant.py
+++ b/snakebite/tests/controllers/test_restaurant.py
@@ -19,9 +19,11 @@ class TestRestaurantCollectionGet(testing.TestBase):
         self.srmock = testing.StartResponseMock()
         self.restaurants = [
             Restaurant(name='a', description='desc', email='a@b.com',
-                       address='Asakusa, Taito-ku, Tokyo', tags=['x', 'y', 'z'], geolocation=[139.79843, 35.712074]),
+                       address='Asakusa, Taito-ku, Tokyo', tags=['x', 'y', 'z'], geolocation=[139.79843, 35.712074],
+                       menus=[Menu(name='menu1', price=1000.00, currency='JPY', images=[], tags=['a', 'b'])]),
             Restaurant(name='b', description='description', email='b@a.com',
-                       address='Roppongi, Minato-ku, Tokyo', tags=['z'], geolocation=[139.731443, 35.662836])
+                       address='Roppongi, Minato-ku, Tokyo', tags=['z'], geolocation=[139.731443, 35.662836],
+                       menus=[Menu(name='menuA', price=400.00, currency='JPY', images=[], tags=['a', 'b'])])
         ]
         for r in self.restaurants:
             r.save()
@@ -47,6 +49,9 @@ class TestRestaurantCollectionGet(testing.TestBase):
             {'query_string': 'geolocation=ab,cd', 'expected': {"status": 400}},
             {'query_string': 'limit=1', 'expected': {"status": 200, "count": 1}},
             {'query_string': 'start=2&limit=1', 'expected': {"status": 200, "count": 0}},
+            {'query_string': 'price=100,', 'expected': {"status": 200, "count": 2}},
+            {'query_string': 'price=100,400', 'expected': {"status": 200, "count": 1}},
+            {'query_string': 'price=800,1200', 'expected': {"status": 200, "count": 1}},
             {'query_string': 'start=1limit=1', 'expected': {"status": 400}}
         ]
         for t in tests:

--- a/snakebite/tests/helpers/test_range.py
+++ b/snakebite/tests/helpers/test_range.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from falcon import testing
+from snakebite.helpers.range import min_max
+from snakebite.constants import INTEGER_MAX
+
+
+class Testrange(testing.TestBase):
+
+    def test_min_max(self):
+        tests = [
+            {'range_str': '', 'expected': (0, INTEGER_MAX)},
+            {'range_str': '', 'type': 'float', 'expected': (0.00, float(INTEGER_MAX))},
+            {'range_str': '1,5', 'type': 'float', 'min': -1, 'max': 10, 'expected': (1.00, 5.00)},
+            {'range_str': '10,-1', 'type': 'int', 'expected': (-1, 10)},
+            {'range_str': '10,', 'type': 'int', 'expected': (10, INTEGER_MAX)},
+            {'range_str': '2,10', 'type': 'str', 'expected': TypeError()}
+        ]
+
+        for test in tests:
+            expected = test.pop('expected')
+            if isinstance(expected, Exception):
+                self.assertRaises(expected.__class__, min_max, **test)
+
+            else:
+                minmax = min_max(**test)
+                self.assertEqual(minmax, expected)


### PR DESCRIPTION
This PR updates the search availability under `/restaurants?price=min,max` such that you can search for restaurants where there exists a menu of price ( min <= price <= max )

In summary, to search for restaurants where menus are priced no more than 500 yen,
`/restaurants?price=,500`