### PR TITLE
[update] do not use pymongo 3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ requires = [
     "falcon==0.2.0b1",
     "Cython==0.21.1",
     "colander==1.0",
+    "pymongo==2.8",
     "mongoengine==0.8.7",
     "gunicorn==18.0"
 ]


### PR DESCRIPTION
This PR updates the list of lib dependencies. With mongoengine failing with latest pymongo lib (version 3.0), we need to explicitly use pymongo 2.8 for now.
