### PR TITLE
[chore] move POST and DELETE rating endpoint to /ratings/menus

### DIFF
--- a/snakebite/controllers/schema/rating.py
+++ b/snakebite/controllers/schema/rating.py
@@ -5,6 +5,5 @@ import colander
 
 
 class MenuRatingSchema(colander.MappingSchema):
-    menu_id = colander.SchemaNode(colander.String())
     user_id = colander.SchemaNode(colander.String())
     rating = colander.SchemaNode(colander.Float(), validator=colander.Range(min=0.0, max=5.0), missing=1)


### PR DESCRIPTION
This PR moves the POST and DELETE menu ratings from `/ratings/menus` to `/ratings/menus/[menu_id]` instead