### PR TITLE
[feature] add batch request restaurant

### DIFF
--- a/snakebite/__init__.py
+++ b/snakebite/__init__.py
@@ -7,7 +7,7 @@ import logging
 import os
 from mongoengine import connection
 from logging.handlers import TimedRotatingFileHandler
-from snakebite.controllers import restaurant, menu, tag, status, rating, user
+from snakebite.controllers import restaurant, menu, tag, status, rating, user, batch
 from snakebite.constants import DATETIME_FORMAT
 
 
@@ -40,6 +40,9 @@ class SnakeBite(object):
         self.app.add_route('/ratings/menus/{id}', rating.Item())
         self.app.add_route('/tags', tag.Collection())
         self.app.add_route('/status', status.Status())
+
+        # batch resources
+        self.app.add_route('/batch/restaurants', batch.RestaurantCollection())
 
     def cors_middleware(self):
         """

--- a/snakebite/controllers/batch.py
+++ b/snakebite/controllers/batch.py
@@ -29,10 +29,11 @@ class RestaurantCollection(object):
         query_params = req.params.get('query')
 
         # get IDs
-        ids = query_params.pop('ids')
-        if not ids:
-            raise HTTPBadRequest(title='Invalid Value',
-                                 description='Missing IDs in URL query')
+        try:
+            ids = query_params.pop('ids')
+        except KeyError:
+            raise HTTPBadRequest(title='Invalid Request',
+                                 description='Missing ID parameter in URL query')
 
         # parse IDs
         ids = ids.split(',')

--- a/snakebite/controllers/batch.py
+++ b/snakebite/controllers/batch.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+import falcon
+import logging
+from snakebite.controllers.hooks import deserialize, serialize
+from snakebite.models.restaurant import Restaurant
+from snakebite.libs.error import HTTPBadRequest
+from snakebite.helpers.geolocation import reformat_geolocations_point_field_to_map
+from mongoengine.errors import DoesNotExist, MultipleObjectsReturned, ValidationError
+
+
+logger = logging.getLogger(__name__)
+
+
+class RestaurantCollection(object):
+    def __init__(self):
+        pass
+
+    def _try_get_restaurant(self, id):
+        try:
+            return Restaurant.objects.get(id=id)
+        except (ValidationError, DoesNotExist, MultipleObjectsReturned) as e:
+            raise HTTPBadRequest(title='Invalid Value', description='Invalid ID provided. {}'.format(e.message))
+
+    @falcon.before(deserialize)
+    @falcon.after(serialize)
+    def on_get(self, req, res):
+        query_params = req.params.get('query')
+
+        # get IDs
+        ids = query_params.pop('ids')
+        if not ids:
+            raise HTTPBadRequest(title='Invalid Value',
+                                 description='Missing IDs in URL query')
+
+        # parse IDs
+        ids = ids.split(',')
+        restaurants = []
+        for id in ids:
+            restaurant = self._try_get_restaurant(id)
+            reformat_geolocations_point_field_to_map(restaurant, 'geolocation')
+            restaurants.append(restaurant)
+
+        res.body = {'items': restaurants, 'count': len(restaurants)}

--- a/snakebite/controllers/hooks/__init__.py
+++ b/snakebite/controllers/hooks/__init__.py
@@ -83,6 +83,8 @@ def serialize(req, res, resource):
             return {k: _to_json(v) for k, v in obj.iteritems()}
         if isinstance(obj, mongo.queryset.queryset.QuerySet):
             return [_to_json(item) for item in obj]
+        if isinstance(obj, list) and isinstance(obj[0], mongo.Document):
+            return [_to_json(item) for item in obj]
         return obj
 
     res.body = json_util.dumps(_to_json(res.body))

--- a/snakebite/tests/controllers/test_batch.py
+++ b/snakebite/tests/controllers/test_batch.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from falcon import testing
+from snakebite.tests import get_test_snakebite
+from snakebite.controllers import batch
+from snakebite.models.restaurant import Restaurant
+import json
+
+
+class TestBatchRestaurantCollectionGet(testing.TestBase):
+
+    def setUp(self):
+        self.resource = batch.RestaurantCollection()
+        self.api = get_test_snakebite().app
+        self.api.add_route('/batch/restaurants', self.resource)
+        self.srmock = testing.StartResponseMock()
+
+        restaurants = [
+            {
+                'name': 'a',
+                'description': 'desc A',
+                'email': 'a@b.com',
+                'address': 'tokyo',
+            },
+            {
+                'name': 'b',
+                'description': 'desc B',
+                'email': 'b@a.com',
+                'address': 'kyoto',
+            }
+        ]
+        self.restaurants = []
+        for r in restaurants:
+            rest = Restaurant(**r)
+            rest.save()
+            self.restaurants.append(rest)
+
+    def tearDown(self):
+        Restaurant.objects(id__in=[r.id for r in self.restaurants]).delete()
+
+    def test_on_get(self):
+
+        tests = [
+            {'query_string': '', 'expected': {'status': 400}},
+            {'query_string': 'ids=', 'expected': {'status': 400}},
+            {'query_string': 'ids=,,,,', 'expected': {'status': 400}},
+            {'query_string': 'ids=invalid', 'expected': {'status': 400}},
+            {'query_string': 'ids={}'.format(self.restaurants[0].id), 'expected': {'status': 200, 'count': 1}},
+            {'query_string': 'ids={}'.format(",".join([str(r.id) for r in self.restaurants])), 'expected': {'status': 200, 'count': len(self.restaurants)}},
+            {'query_string': 'ids={}&start=ignored'.format(",".join([str(r.id) for r in self.restaurants])), 'expected': {'status': 200, 'count': len(self.restaurants)}}
+        ]
+
+        for t in tests:
+            res = self.simulate_request('/batch/restaurants',
+                                        query_string=t['query_string'],
+                                        method='GET',
+                                        headers={'accept': 'application/json'})
+
+            self.assertTrue(isinstance(res, list))
+            body = json.loads(res[0])
+            self.assertTrue(isinstance(body, dict))
+
+            if t['expected']['status'] != 200:  # expected erroneous requests
+                self.assertNotIn('count', body.keys())
+                self.assertIn('title', body.keys())
+                self.assertIn('description', body.keys())
+                continue
+
+            self.assertItemsEqual(["count", "items"], body.keys())
+            got = body['count']
+            want = t['expected']['count']
+            self.assertEqual(got, want, "{}| got: {}, want: {}".format(t['query_string'], got, want))


### PR DESCRIPTION
This PR initiates the `/batch` endpoints for making batch requests on Snakebite via one single HTTP requests (inspired by [batch requests with Facebook](https://developers.facebook.com/docs/graph-api/making-multiple-requests)).

More particularly, this PR adds the `GET /batch/restaurants?ids=A,B,C` endpoint such that the client can request for a batch of restaurants by supplying a list of restaurant IDs in query params